### PR TITLE
Encoding problems

### DIFF
--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -26,8 +26,9 @@ module Houston
 
     def message
       json = payload.to_json
+      device_token = [@device.gsub(/[<\s>]/, '')].pack('H*')
 
-      "\0\0 #{[@device.gsub(/[<\s>]/, '')].pack('H*')}\0#{json.length.chr}#{json}"
+      [0, 0, 32, device_token, 0, json.bytes.count, json].pack('ccca*cca*')
     end
 
     def mark_as_sent!


### PR DESCRIPTION
Using string interpolation in Notification#message causes the string to become ASCII-8BIT encoded because of the Array#pack call.

This pull request fixes it so messages containing UTF-8 characters don't cause a _incompatible character encodings: ASCII-8BIT and UTF-8_ exception.

It's also necessary to use `json.bytes.count`, otherwise a wrong count will be returned.
