### PR TITLE
Fix check for required options

### DIFF
--- a/lib/houston/connection.rb
+++ b/lib/houston/connection.rb
@@ -9,7 +9,7 @@ module Houston
         return unless block_given?
 
         [:certificate, :passphrase, :host, :port].each do |option|
-          raise ArgumentError, "Missing connection parameter: #{option}" unless option
+          raise ArgumentError, "Missing connection parameter: #{option}" unless options[option]
         end
 
         socket = TCPSocket.new(options[:host], options[:port])


### PR DESCRIPTION
The check for the required options in connection.rb was checking that the option key exists instead of checking that the option value is set.
