### PR TITLE
Optionally manage your own connections

### DIFF
--- a/lib/houston/client.rb
+++ b/lib/houston/client.rb
@@ -6,7 +6,7 @@ module Houston
   APPLE_DEVELOPMENT_FEEDBACK_URI = "apn://feedback.push.apple.com:2196"
 
   class Client
-    attr_accessor :gateway_uri, :feedback_uri, :certificate, :passphrase
+    attr_accessor :gateway_uri, :feedback_uri, :certificate, :passphrase, :gateway_connection, :feedback_connection
 
     def initialize
       @gateway_uri = ENV['APN_GATEWAY_URI']
@@ -32,7 +32,7 @@ module Houston
     def push(*notifications)
       return if notifications.empty?
 
-      Connection.open(connection_options_for_endpoint(:gateway)) do |connection|
+      use_connection(:gateway) do |connection|
         notifications.flatten.each do |notification|
           next unless notification.kind_of?(Notification)
           next if notification.sent?
@@ -46,7 +46,7 @@ module Houston
     def devices
       devices = []
 
-      Connection.open(connection_options_for_endpoint(:feedback)) do |connection|
+      use_connection(:feedback) do |connection|
         while line = connection.read(38)
           feedback = line.unpack('N1n1H140')
           token = feedback[2].scan(/.{0,8}/).join(' ').strip
@@ -57,22 +57,34 @@ module Houston
       devices
     end
 
+    def connection_options_for_endpoint(endpoint = :gateway)
+      uri = case endpoint
+              when :gateway then URI(@gateway_uri)
+              when :feedback then URI(@feedback_uri)
+              else
+                raise ArgumentError
+            end
+
+      {
+        certificate: @certificate,
+        passphrase: @passphrase,
+        host: uri.host,
+        port: uri.port
+      }
+    end
+
     private
 
-      def connection_options_for_endpoint(endpoint = :gateway)
-        uri = case endpoint
-                when :gateway then URI(@gateway_uri)
-                when :feedback then URI(@feedback_uri)
-                else
-                  raise ArgumentError
-              end
+      def use_connection(kind)
+        return unless block_given? and kind
 
-        {
-          certificate: @certificate,
-          passphrase: @passphrase,
-          host: uri.host,
-          port: uri.port
-        }
+        connection = (send(:"#{kind}_connection") || Connection.new(connection_options_for_endpoint(kind)))
+        should_close = !connection.open?
+        connection.open unless connection.open?
+
+        yield connection
+
+        connection.close if should_close
       end
   end
 end

--- a/lib/houston/connection.rb
+++ b/lib/houston/connection.rb
@@ -30,7 +30,7 @@ module Houston
     end
 
     def open
-      return if @socket and @ssl
+      return if open?
 
       @socket = TCPSocket.new(@options[:host], @options[:port])
 
@@ -43,9 +43,16 @@ module Houston
       @ssl.connect
     end
 
+    def open?
+      (@socket and @ssl) != nil
+    end
+
     def close
       @ssl.close
+      @ssl = nil
+
       @socket.close
+      @socket = nil
     end
   end
 end


### PR DESCRIPTION
You can test this with the following script in the Houston directory (I'd love to write actual tests at some point)

``` ruby

require 'bundler'
Bundler.setup

token = 'asdf...'
cert = '/somewhere/apple_push_notification.pem'
message = 'Whatever'

client = Houston::Client.development
client.certificate = File.read(cert)

# Initialize your own connection.
# Note that it uses the `client.connection_options_for_endpoint` method. Not a fan of this.
client.gateway_connection = Houston::Connection.new(client.connection_options_for_endpoint(:gateway))

# You have to explicitly open the connection since you are managing it.
client.gateway_connection.open

notification = Houston::Notification.new(device: token)
notification.alert = message

client.push(notification)

puts "Still open: #{client.gateway_connection.open?.inspect}"
```

Basically it checks for the instance variable or will make a new connection. If the connection is open when it's called, it won't close it since it assumes you are managing it.

I think the API for creating a connection with the client needs to be cleaned up. Would love some feedback.
