### PR TITLE
Do not overwrite the user provided payload

### DIFF
--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -20,7 +20,7 @@ module Houston
 
     def payload
       json = {}.merge(@custom_data || {})
-      json['aps'] = {}
+      json['aps'] ||= {}
       json['aps']['alert'] = @alert if @alert
       json['aps']['badge'] = @badge.to_i rescue 0 if @badge
       json['aps']['sound'] = @sound if @sound


### PR DESCRIPTION
Allow users of Notification to provide the full data, including the 'aps' key and its contents.

Specially interesting if you are using the command line tool, and you want to test 'alert' as dictionary with 'loc-key' and 'loc-args'.
