### PR TITLE
Automatically handle dropped connections from APNs

### DIFF
--- a/lib/houston/client.rb
+++ b/lib/houston/client.rb
@@ -6,7 +6,7 @@ module Houston
   APPLE_DEVELOPMENT_FEEDBACK_URI = "apn://feedback.sandbox.push.apple.com:2196"
 
   class Client
-    attr_accessor :gateway_uri, :feedback_uri, :certificate, :passphrase
+    attr_accessor :gateway_uri, :feedback_uri, :certificate, :passphrase, :timeout
 
     class << self
       def development
@@ -29,19 +29,51 @@ module Houston
       @feedback_uri = ENV['APN_FEEDBACK_URI']
       @certificate = ENV['APN_CERTIFICATE']
       @passphrase = ENV['APN_CERTIFICATE_PASSPHRASE']
+      @timeout = ENV['APN_TIMEOUT'] || 0.5
     end
 
     def push(*notifications)
       return if notifications.empty?
 
+      notifications.flatten!
+      error = nil
+
       Connection.open(@gateway_uri, @certificate, @passphrase) do |connection|
-        notifications.flatten.each do |notification|
+        ssl = connection.ssl
+
+        notifications.each_with_index do |notification, index|
           next unless notification.kind_of?(Notification)
           next if notification.sent?
 
+          notification.id = index
+
           connection.write(notification.message)
           notification.mark_as_sent!
+
+          break if notifications.count == 1 || notification == notifications.last
+
+          read_socket, write_socket = IO.select([ssl], [ssl], [ssl], nil)
+          if (read_socket && read_socket[0])
+            error = connection.read(6)
+            break
+          end
         end
+
+        return if notifications.count == 1
+
+        unless error
+          read_socket, write_socket = IO.select([ssl], nil, [ssl], timeout)
+          if (read_socket && read_socket[0])
+            error = connection.read(6)
+          end
+        end
+      end
+
+      if error
+        command, status, index = error.unpack("cci")
+        notifications.slice!(0..index)
+        notifications.each(&:mark_as_unsent!)
+        push(*notifications)
       end
     end
 

--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -44,6 +44,10 @@ module Houston
       @sent_at = Time.now
     end
 
+    def mark_as_unsent!
+      @sent_at = nil
+    end
+
     def sent?
       !!@sent_at
     end


### PR DESCRIPTION
About 3 months ago I tried to make Houston automatically handle dropped connections from APNs. It's been in production ever since, pushing many thousands of notifications per day without issues, so I'm bringing it here for discussion.

As you probably know, whenever APNs encounters an invalid device token it will drop the connection and no further notifications will get delivered.

Here's my proposal to fix this: https://github.com/jcxplorer/houston/compare/dropped-connections

My patch does two things:
- Switches to the enhanced notification format.
- If there's more than one notification being sent, we'll check if APNs has returned an error before disconnecting. Because we're now using the enhanced notification format we know which notification failed so we can skip it and continue from the next one.

There are two `IO.select` calls in that code. The first one that executes inside the loop is async so there's no slowdown of any kind. The last one is a synchronous call with a configurable timeout with a default of 0.5 seconds, so we don't disconnect right away after sending many push notifications in case we still get an error.

Again, if you're sending only one notification, the synchronous `IO.select` never gets executed, because there's nothing to recover from, thus not slowing down sending a single push notification.

I think this implementation is simple enough and so far it has worked great. It also lets you use Houston like before, no changes required. If this is something you'd like, I'll be happy to port it to the latest version of Houston and send a pull request!
