### PR TITLE
Don't require an alert message if content_available (newsstand) is set

### DIFF
--- a/bin/apn
+++ b/bin/apn
@@ -63,7 +63,7 @@ command :push do |c|
       end
     end
 
-    unless @alert or @badge or @newsstand or @data
+    unless @alert or @badge or @content_available or @data
       placeholder = "Enter your alert message"
       @alert = ask_editor placeholder
       say_error "Payload contents required" and abort if @alert.nil? or @alert == placeholder


### PR DESCRIPTION
[840a236](https://github.com/nomad/houston/commit/840a236#diff-1) introduced a bug which requires that a message is entered when using the newsstand/content_available flag. The variable was renamed, causing the check to fail.
