### PR TITLE
Use modern APNs format.

### DIFF
--- a/lib/houston.rb
+++ b/lib/houston.rb
@@ -5,3 +5,4 @@ end
 require 'houston/client'
 require 'houston/notification'
 require 'houston/connection'
+require 'houston/frame'

--- a/lib/houston/frame.rb
+++ b/lib/houston/frame.rb
@@ -1,0 +1,75 @@
+require 'json'
+
+module Houston
+  class Frame
+    COMMAND = 2
+
+    def initialize(token, payload, id, expiry, priority)
+      @items = []
+      @items.push FrameItem.device_token(token)
+      @items.push FrameItem.payload(payload)
+      @items.push FrameItem.identifier(id)
+      @items.push FrameItem.expiry(expiry)
+      @items.push FrameItem.priority(priority)
+    end
+
+    def frame
+      @items.join
+    end
+
+    def frame_length
+      frame.bytesize
+    end
+
+    def to_s
+      [COMMAND, frame_length].pack('CN') + frame
+    end
+  end
+
+  class FrameItem
+    DEVICE_TOKEN_NO = 1
+    PAYLOAD_NO      = 2
+    IDENTIFIER_NO   = 3
+    EXPIRATION_NO   = 4
+    PRIORITY_NO     = 5
+
+    def self.device_token(token)
+      hex = [token.gsub(/[<\s>]/, '')].pack('H*')
+      new DEVICE_TOKEN_NO, hex.bytesize, hex
+    end
+
+    def self.payload(payload)
+      json = payload.to_json
+      new PAYLOAD_NO, json.bytesize, json
+    end
+
+    def self.identifier(id)
+      new IDENTIFIER_NO, 4, id
+    end
+
+    def self.expiry(time)
+      new EXPIRATION_NO, 4, @expiry.to_i
+    end
+
+    def self.priority(value)
+      new PRIORITY_NO, 1, value, 'C'
+    end
+
+    def initialize(number, data_length, data, directive = nil)
+      @number = number
+      @data_length = data_length
+      @data = data
+      @directive = directive
+      @directive ||= case data
+      when String
+        'A*'
+      when Fixnum
+        'N'
+      end
+    end
+
+    def to_s
+      [@number, @data_length, @data].pack("Cn#{@directive}")
+    end
+  end
+end

--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 module Houston
   class Notification
     attr_accessor :token, :alert, :badge, :sound, :content_available, :custom_data, :id, :expiry
@@ -14,7 +12,7 @@ module Houston
       @badge = options.delete(:badge)
       @sound = options.delete(:sound)
       @expiry = options.delete(:expiry)
-      @id = options.delete(:id)
+      @id = options.delete(:id).to_i
       @content_available = options.delete(:content_available)
 
       @custom_data = options
@@ -27,17 +25,14 @@ module Houston
       json['aps']['badge'] = @badge.to_i rescue 0 if @badge
       json['aps']['sound'] = @sound if @sound
       json['aps']['content-available'] = 1 if @content_available
-
       json
     end
 
     def message
-      json = payload.to_json
-      device_token = [@token.gsub(/[<\s>]/, '')].pack('H*')
       @expiry ||= Time.now + 86400
-      @id ||= 0
-
-      [1, @id, @expiry.to_i, 0, 32, device_token, 0, json.bytes.count, json].pack('ciicca*cca*')
+      priority = @content_available ? 5 : 10
+      frame = Frame.new @token, payload, @id, @expiry, priority
+      frame.to_s
     end
 
     def mark_as_sent!
@@ -53,3 +48,5 @@ module Houston
     end
   end
 end
+
+

--- a/test/houston/notification_test.rb
+++ b/test/houston/notification_test.rb
@@ -1,0 +1,65 @@
+require_relative '../test_helper'
+
+describe Houston::Notification do
+  describe ".new" do
+    it "accepts the standard APN paramaters and adds the rest to custom data" do
+      now = Time.now
+      n = Houston::Notification.new token: 'ABC',
+                                    alert: 'Hi!',
+                                    badge: 8,
+                                    sound: 'wuff.aif',
+                                    expiry: now,
+                                    id: 42,
+                                    content_available: 1,
+                                    foo: 'foo',
+                                    bar: 'bar'
+      n.token.must_equal 'ABC'
+      n.device.must_equal n.token
+      n.alert.must_equal 'Hi!'
+      n.badge.must_equal 8
+      n.sound.must_equal 'wuff.aif'
+      n.expiry.must_equal now
+      n.content_available.must_equal 1
+      n.id.must_equal 42
+      n.custom_data.must_equal foo: 'foo', bar: 'bar'
+    end
+  end
+
+  describe '#payload' do
+    specify 'an empty payload' do
+      n = Houston::Notification.new
+      n.payload.must_equal({ 'aps' => {} })
+    end
+
+    specify 'with alert' do
+      n = Houston::Notification.new alert: 'Hi!'
+      n.payload.must_equal({ 'aps' => { 'alert' => 'Hi!' } })
+    end
+
+    specify 'with badge' do
+       n = Houston::Notification.new badge: '8'
+       n.payload.must_equal({ 'aps' => { 'badge' => 8 } })
+    end
+
+    specify 'with sound' do
+      n = Houston::Notification.new sound: 'wuff.aif'
+      n.payload.must_equal({ 'aps' => { 'sound' => 'wuff.aif' } })
+    end
+
+    specify 'with content-available' do
+      n = Houston::Notification.new content_available: true
+      n.payload.must_equal({ 'aps' => { 'content-available' => 1 } })
+    end
+
+    specify 'with custom data' do
+      n = Houston::Notification.new foo: 'bar'
+      n.payload.must_equal({:foo=>"bar", "aps"=>{}})
+    end
+  end
+
+  specify '#message' do
+    n = Houston::Notification.new(id: 22, expiry: 0, token: 'device_token', alert: 'Hello iPhone', badge: 3, sound: 'awesome.caf')
+    n.message.chomp.must_equal "\x02\x00\x00\x00^\x01\x00\x06\xDE\xF2\xCE\xFD\x84\xE7\x02\x00@{\"aps\":{\"alert\":\"Hello iPhone\",\"badge\":3,\"sound\":\"awesome.caf\"}}\x03\x00\x04\x00\x00\x00\x16\x04\x00\x04\x00\x00\x00\x00\x05\x00\x01".force_encoding(Encoding::ASCII_8BIT)
+  end
+
+end


### PR DESCRIPTION
We were still using legacy Enhanced Notification Format.

This pull request implements: https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW4
