### PR TITLE
The sound key must be present and nil to send silent/hidden push notifications

### DIFF
--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -28,7 +28,7 @@ module Houston
       json['aps'] ||= {}
       json['aps']['alert'] = @alert if @alert
       json['aps']['badge'] = @badge.to_i rescue 0 if @badge
-      json['aps']['sound'] = @sound if @sound
+      json['aps']['sound'] = @sound ? @sound : nil
       json['aps']['content-available'] = 1 if @content_available
 
       json


### PR DESCRIPTION
If the sound key is not present, truly silent push notifications are never delivered. That is, notifications without a sound or a message, but probably with the content-available bit flipped. Strange as it may be, a nil value assigned to the sound key fixes this issue.
