### PR TITLE
Fix bug that skips notification on error status 10

### DIFF
--- a/lib/houston/client.rb
+++ b/lib/houston/client.rb
@@ -72,8 +72,6 @@ module Houston
 
       if error
         command, status, index = error.unpack("ccN")
-        # status == 10 means shutdown, and the given id is the last one successfully sent
-        index += 1 if status == 10
         notifications.slice!(0..index)
         notifications.each(&:mark_as_unsent!)
         push(*notifications)


### PR DESCRIPTION
The current behavior incorrectly skips a notification when an error
status code of 10 is received from Apple. Consider a scenario where the
notifications array looks like:

``` ruby
notifications = [notification_a, notification_b, notification_c]
```

Let's say that after writing notification_a, Apple responds with an
error-response packet that has a status code of 10 and an Identifier of
0, indicating that `notification_a` was the last (and only) notification
successfully sent.

With the current logic, index would be set to 0 and then bumped to 1.
The `slice!` on notifications would then modify notifications so that its
value is just `[notification_c]`. So `notification_a` would've been
successfully sent, `notification_c` would be queued up for sending, but
`notification_b` would be dropped and never sent.

Getting rid of the increment to `index` fixes this bug, so that both
`notification_b` and `notification_c` will be queued up for resending.

Paired with @tylercal on this.
