### PR TITLE
allow expiration to be set as epoch or ruby time

### DIFF
--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -75,7 +75,7 @@ module Houston
     end
 
     def expiration_item
-      [4, 4, @expiry].pack('cnN') unless @expiry.nil?
+      [4, 4, @expiry.to_i].pack('cnN') unless @expiry.nil?
     end
 
     def priority_item


### PR DESCRIPTION
Apple expects seconds since epoch (unix time), but it would be nice to be able to use either.
