### PR TITLE
Fix and format sent and unsent messages

### DIFF
--- a/bin/apn
+++ b/bin/apn
@@ -81,28 +81,22 @@ command :push do |c|
       @notifications << notification
     end
 
-    client = @environment == :production ? Houston::Client.production : Houston::Client.development
+    client = Houston::Client.send(@environment)
     client.certificate = File.read(@certificate)
     client.passphrase = @passphrase
 
     begin
       client.push(*@notifications)
 
-      sent = @notifications.select{|notification| notification.sent?}
-      unsent = @notifications.select{|notification| not notification.sent?}
+      sent, unsent = @notifications.partition{|notification| notification.sent?}
 
-      case sent.length
-      when 1
-        say_ok "#{sent.length} push notification sent successfully"
-      else
-        say_ok "#{sent.length} push notifications sent successfully"
+      if sent.any?
+        say_ok "#{sent.length} push notification#{'s' unless sent.one?} sent successfully"
       end
 
-      case unsent.length
-      when 1
-        say_ok "#{unsent.length} push notification unsuccessful (#{unsent.join(", ")})"
-      else
-        say_ok "#{unsent.length} push notifications unsuccessful (#{unsent.join(", ")})"
+      if unsent.any?
+        tokens = unsent.map{|notification| "\n - #{notification.token}"}.join
+        say_error "#{unsent.length} push notification#{'s' unless unsent.one?} unsuccessful #{tokens}"
       end
 
     rescue => message


### PR DESCRIPTION
cleaned up reporting a little bit.
#### success

before

```
1 push notification sent successfully
0 push notifications unsuccessful ()
```

after

```
1 push notification sent successfully
```
#### failure

before

```
0 push notifications sent successfully
1 push notification unsuccessful
(#<Houston::Notification:0x007f9f43164b78>)
```

after

```
1 push notification unsuccessful 
 - < .. token .. >
```
