### PR TITLE
Adding the ability pass in options to Houston::Client.new 

### DIFF
--- a/lib/houston/client.rb
+++ b/lib/houston/client.rb
@@ -24,12 +24,12 @@ module Houston
       end
     end
 
-    def initialize
-      @gateway_uri = ENV['APN_GATEWAY_URI']
-      @feedback_uri = ENV['APN_FEEDBACK_URI']
-      @certificate = ENV['APN_CERTIFICATE']
-      @passphrase = ENV['APN_CERTIFICATE_PASSPHRASE']
-      @timeout = Float(ENV['APN_TIMEOUT'] || 0.5)
+    def initialize(gateway_uri=nil, feeback_uri=nil, cert=nil, passphase=nil, timeout=nil)
+      @gateway_uri  = gateway_uri || ENV['APN_GATEWAY_URI']
+      @feedback_uri = feedback_uri || ENV['APN_FEEDBACK_URI']
+      @certificate  = cert || ENV['APN_CERTIFICATE']
+      @passphrase   = passphrase || ENV['APN_CERTIFICATE_PASSPHRASE']
+      @timeout      = Float(timeout || ENV['APN_TIMEOUT'] || 0.5)
     end
 
     def push(*notifications)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -74,6 +74,44 @@ describe Houston::Client do
       end
     end
 
+    context 'passing options through initialize options' do
+      let(:apn_gateway_uri)   { "apn://gateway.example.com" }
+      let(:apn_feedback_uri)  { "apn://feedback.example.com" }
+      let(:apn_cert)          { "path/to/certificate" }
+      let(:apn_cert_pass)     { "passphrase" }
+      let(:apn_timeout)       { "10.0" }
+
+      subject do
+        Houston::Client.new(apn_gateway_uri, apn_feedback_uri, apn_cert, apn_cert_pass, apn_timeout)
+      end
+
+      describe '#gateway_uri' do
+        subject { super().gateway_uri }
+        it { should == apn_gateway_uri }
+      end
+
+      describe '#feedback_uri' do
+        subject { super().feedback_uri }
+        it { should == apn_feedback_uri }
+      end
+
+      describe '#certificate' do
+        subject { super().certificate }
+        it { should == apn_cert }
+      end
+
+      describe '#passphrase' do
+        subject { super().passphrase }
+        it { should == apn_cert_pass }
+      end
+
+      describe '#timeout' do
+        subject { super().timeout }
+        it { should be_a(Float) }
+        it { should == Float(apn_timeout) }
+      end
+    end
+
     describe '#push' do
       it 'should accept zero arguments' do
         expect(Houston::Client.development.push()).to be_nil()


### PR DESCRIPTION
We have a need to be able to initialize a Houston::Client with specific options and would like the ability to pass options in.  Currently, it only allows you to rely on ENV variables.

This commit does not break that existing functionality.
