### PR TITLE
Alert Truncation

### DIFF
--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -5,8 +5,8 @@ module Houston
     MAXIMUM_PAYLOAD_SIZE = 256
     DEFAULT_OMISSION = '...'
 
-    attr_accessor :token, :alert, :badge, :sound, :content_available, :custom_data, :id, :expiry, :priority, :omission
-    attr_reader :sent_at, :truncation
+    attr_accessor :token, :alert, :badge, :sound, :content_available, :custom_data, :id, :expiry, :priority, :truncation, :omission
+    attr_reader :sent_at
 
     alias :device :token
     alias :device= :token=
@@ -62,10 +62,6 @@ module Houston
 
     def valid?
       payload_valid?(payload)
-    end
-
-    def truncation=(truncation)
-      @truncation = !!truncation
     end
 
     private

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -252,30 +252,6 @@ describe Houston::Notification do
     end
   end
 
-  describe '#truncation=' do
-    context 'When parameter is true' do
-      it 'should return true' do
-        notification = Houston::Notification.new
-        notification.truncation = true
-        expect(notification.truncation).to be_true
-      end
-    end
-    context 'When parameter is false' do
-      it 'should return false' do
-        notification = Houston::Notification.new
-        notification.truncation = false
-        expect(notification.truncation).to be_false
-      end
-    end
-    context 'When parameter is nil' do
-      it 'should return false' do
-        notification = Houston::Notification.new
-        notification.truncation = nil
-        expect(notification.truncation).to be_false
-      end
-    end
-  end
-
   def create_payload(size)
     payload = {
       'aps' => {


### PR DESCRIPTION
I implemented alert truncation for invalid payloads. It will truncate the alert if the payload exceeds the maximum payload size. <code>Notification</code> takes two more parameters <code>truncation</code> and <code>omission</code>.

<code>truncation</code> may be <code>true</code>, <code>false</code> or <code>nil</code>. Default is <code>nil</code>.
<code>omission</code> may be any string, <code>false</code> or <code>nil</code>. Default is <code>...</code>.

By default it won't truncate the alert. It will truncate if <code>truncation</code> is <code>true</code>.

Usage:

``` ruby
require 'houston'

APN = Houston::Client.development
APN.certificate = File.read("/path/to/apple_push_notification.pem")

token = "<ce8be627 2e43e855 16033e24 b4c28922 0eeda487 9c477160 b2545e95 b68b5969>"

notification = Houston::Notification.new(device: token)
notification.alert = "Really long message which will exceed the 256 bytes maximum payload size. So it will be truncated and omission will be added to the end of the alert."

notification.badge = 57
notification.sound = "sosumi.aiff"
notification.content_available = true
notification.custom_data = {foo: "bar"}

notification.truncation = true

APN.push(notification)
# Alert will be sent as:
# Really long message which will exceed the 256 bytes maximum payload size. So it will be truncated and omission will be added to the end of th...
```

What do you think?
