### PR TITLE
Notification payload hash to hash with access by string keys

### DIFF
--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -24,7 +24,8 @@ module Houston
     end
 
     def payload
-      json = {}.merge(@custom_data || {})
+      json = {}.merge(@custom_data || {}).inject({}){|h,(k,v)| h[k.to_s] = v; h}
+
       json['aps'] ||= {}
       json['aps']['alert'] = @alert if @alert
       json['aps']['badge'] = @badge.to_i rescue 0 if @badge
@@ -60,7 +61,7 @@ module Houston
     end
 
     private
-    
+
     def device_token_item
       [1, 32, @token.gsub(/[<\s>]/, '')].pack('cnH64')
     end

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -86,16 +86,16 @@ describe Houston::Notification do
           'sound' => 'sosumi.aiff',
           'content-available' => 1
         },
-        :key1 => 1,
-        :key2 => 'abc'
+        'key1' => 1,
+        'key2' => 'abc'
       })
     end
 
     it 'should create a dictionary of only custom data and empty aps' do
       expect(Houston::Notification.new(key1: 123, key2: 'xyz').payload).to eq({
         'aps' => {},
-        :key1 => 123,
-        :key2 => 'xyz'
+        'key1' => 123,
+        'key2' => 'xyz'
       })
     end
 
@@ -127,6 +127,13 @@ describe Houston::Notification do
       notification_options = { :badge => 567, 'aps' => { 'loc-key' => 'my-key' } }
       expect(Houston::Notification.new(notification_options).payload).to eq({
         'aps' => { 'loc-key' => 'my-key', 'badge' => 567 }
+      })
+    end
+
+    it 'should create notification from hash with string and symbol keys' do
+      notification_options = { :badge => 567, :aps => { 'loc-key' => 'my-key' } }
+      expect(Houston::Notification.new(notification_options).payload['aps']).to eq({
+        'loc-key' => 'my-key', 'badge' => 567
       })
     end
   end


### PR DESCRIPTION
Creating Notification from hash with 'aps' key as :symbol instead of 'string' will lose it in payload. That's because 'aps' is read as string key only on initialization. Using HashWithIndifferentAccess would require loading ActiveSupport and would be too big overhead imho...

```
  notification = Houston::Notification.new(
    :device => push_token,
    :badge => push_badge_counter,
    :sound => 'default',
    :aps => { 'alert' => { 'loc-key' => 'foo', 'loc-args' => ['bar'] }})
```
