### PR TITLE
Attach the server error response to failed notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,34 @@ connection.write(notification.message)
 connection.close
 ```
 
+### Logging server errors
+The notification server can respond with some error information for failed deliveries. By default, this information is logged to STDOUT.
+
+Logger initialization can be customized:
+
+```ruby
+APN = Houston::Client.development
+APN.logger = Logger.new(STDERR) # will log to STDERR
+
+APN.logger = Rails.logger # if using houston from a rails app, will use the Rails application logger.
+
+```
+
+Learn more about logger initialization here http://www.ruby-doc.org/stdlib-2.0.0/libdoc/logger/rdoc/Logger.html#class-Logger-label-How+to+create+a+logger
+
+Server error messages on `push` calls are logged at WARN level.
+
+The error code and matching message can be accessed per notification, for instance:
+
+```ruby
+APN.push(notification)
+# imagine notification failure by server error on push
+if notification.apns_error
+  puts "Failed to send notification. Server responded '#{notification.apns_error}'. Error code was #{notification.apns_error_code}."
+end
+```
+
+
 ### Feedback Service
 
 Apple provides a feedback service to query for unregistered device tokens, these are devices that have failed to receive a push notification and should be removed from your application. You should periodically query for and remove these devices, Apple audits providers to ensure they are removing unregistered devices. To obtain the list of unregistered device tokens:

--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -4,7 +4,8 @@ module Houston
   class Notification
     MAXIMUM_PAYLOAD_SIZE = 256
 
-    attr_accessor :token, :alert, :badge, :sound, :content_available, :custom_data, :id, :expiry, :priority
+    attr_accessor :token, :alert, :badge, :sound, :content_available, :custom_data, :id, :expiry, :priority,
+      :apns_error_code
     attr_reader :sent_at
 
     alias :device :token
@@ -57,6 +58,22 @@ module Houston
 
     def valid?
       payload.to_json.bytesize <= MAXIMUM_PAYLOAD_SIZE
+    end
+
+    def apns_error
+      {
+        0 => nil,
+        1 => "Processing error",
+        2 => "Missing device token",
+        3 => "Missing topic",
+        4 => "Missing payload",
+        5 => "Invalid token size",
+        6 => "Invalid topic size",
+        7 => "Invalid payload size",
+        8 => "Invalid token",
+        10 => "Shutdown",
+        255 => "Unknown error"
+      }[@apns_error_code]
     end
 
     private


### PR DESCRIPTION
Add the ability to set notification server error information per notification while trying to send a push.
It also logs the error if any. The logger is customizable.

More information about APNS errors on table 5.1 Error Codes:
https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/CommunicatingWIthAPS.html
