### PR TITLE
Fixing nonzero nil error when an apns status has not been set

### DIFF
--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -81,7 +81,7 @@ module Houston
     end
 
     def error
-      APNSError.new(APNSError::CODES[@apns_error_code]) if @apns_error_code.nonzero?
+      APNSError.new(APNSError::CODES[@apns_error_code]) if @apns_error_code && @apns_error_code.nonzero?
     end
 
     private

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -247,4 +247,31 @@ describe Houston::Notification do
       expect(items.find { |item| item[0] == 5 }).to be_nil
     end
   end
+
+  describe '#error' do
+    context 'a status code has been set' do
+      it 'returns an error object mapped to that status code' do
+        status_code = 1
+        notification = Houston::Notification.new(notification_options)
+        notification.apns_error_code = status_code
+        expect(notification.error.message).to eq(Houston::Notification::APNSError::CODES[status_code])
+      end
+    end
+
+    context 'a status code has been set to 0' do
+      it 'returns nil' do
+        status_code = 0
+        notification = Houston::Notification.new(notification_options)
+        notification.apns_error_code = status_code
+        expect(notification.error).to be_nil
+      end
+    end
+
+    context 'a status code has not been set' do
+      it 'returns nil' do
+        notification = Houston::Notification.new(notification_options)
+        expect(notification.error).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes bug where calling error on a notification that does not have an APN status code would throw an exception:

undefined method `nonzero?' for nil:NilClass
/data/sidereel/shared/bundle/ruby/2.1.0/gems/houston-2.2.0/lib/houston/notification.rb:84:in`error'
