### PR TITLE
IO.select only block for readability; introduce timeout

### DIFF
--- a/lib/houston/client.rb
+++ b/lib/houston/client.rb
@@ -50,7 +50,7 @@ module Houston
           connection.write(notification.message)
           notification.mark_as_sent!
 
-          read_socket, write_socket = IO.select([ssl], [ssl], [ssl], nil)
+          read_socket, write_socket = IO.select([ssl], [], [ssl], timeout)
           if (read_socket && read_socket[0])
             if error = connection.read(6)
               command, status, index = error.unpack("ccN")


### PR DESCRIPTION
Don't block for a write_socket; instead, wait for #timeout seconds for read_socket to become readable before bailing out.

This begins to address an issue https://github.com/nomad/houston/issues/72 which is common with and documented within https://github.com/grocer/grocer/issues/14 and https://github.com/grocer/grocer/pull/43 . It introduces a performance penalty.

I realize you may have had other plans for `APN_TIMEOUT`; that part is just a guess.
