### PR TITLE
Continue on invalid token

### DIFF
--- a/lib/houston/client.rb
+++ b/lib/houston/client.rb
@@ -56,6 +56,7 @@ module Houston
               command, status, index = error.unpack("ccN")
               notification.apns_error_code = status
               notification.mark_as_unsent!
+              push(notifications[notification.id + 1..-1])
             end
           end
         end

--- a/lib/houston/client.rb
+++ b/lib/houston/client.rb
@@ -50,7 +50,7 @@ module Houston
           connection.write(notification.message)
           notification.mark_as_sent!
 
-          read_socket, write_socket = IO.select([ssl], [ssl], [ssl], nil)
+          read_socket, write_socket = IO.select([ssl], [], [ssl], timeout)
           if (read_socket && read_socket[0])
             if error = connection.read(6)
               command, status, index = error.unpack("ccN")


### PR DESCRIPTION
This is not an ideal solution, but it makes sure sending a batch of notifications will not fail halfway through, because of 1 illegal device token.
This PR is based on https://github.com/nomad/houston/pull/73, so it will generate some overhead while waiting for the `read_socket`.

When an error is encountered, the `push` method will be invoked again, with push notifications that have not yet been processed. (Everything after the index of the failed notification)
