### PR TITLE
Read stored certificate file, or use the data in the ENV var as fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ notification.custom_data = {foo: "bar"}
 APN.push(notification)
 ```
 
+## Configuration
+
+Houston will attempt to load configuration data from environment variables, if they're present. The following variables will be used.
+
+| Environment Variable | Description |
+|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `APN_GATEWAY_URI` | The base URI for the APNS service to use. If left blank, will use the default APNS Production Gateway URI. |
+| `APN_FEEDBACK_URI` | The base URI for the APNS feedback service to use. If left blank, will use the default APNS Production Feedback URI. |
+| `APN_CERTIFICATE` | The file path to a valid APNS push certificate in `.pem` format (see "[Converting Your Certificate](#converting-your-certificate)" below). |
+| `APN_CERTIFICATE_DATA` | The contents of a valid APNS push certificate in `.pem` format (see "[Converting Your Certificate](#converting-your-certificate)" below); used in lieu of `APN_CERTIFICATE` if that variable is not provided. |
+| `APN_CERTIFICATE_PASSPHRASE` | If the APNS certificate is protected by a passphrase, provide this variable to use when decrypting it. |
+| `APN_TIMEOUT` | The timeout used when communicating with APNS. If not provided, the default of 0.5 seconds is used. |
+
 ### Error Handling
 
 If an error occurs when sending a particular notification, its `error` attribute will be populated:

--- a/lib/houston/client.rb
+++ b/lib/houston/client.rb
@@ -27,7 +27,7 @@ module Houston
     def initialize
       @gateway_uri = ENV['APN_GATEWAY_URI']
       @feedback_uri = ENV['APN_FEEDBACK_URI']
-      @certificate = File.read(ENV['APN_CERTIFICATE']) if ENV['APN_CERTIFICATE']
+      @certificate = certificate_data
       @passphrase = ENV['APN_CERTIFICATE_PASSPHRASE']
       @timeout = Float(ENV['APN_TIMEOUT'] || 0.5)
     end
@@ -79,6 +79,17 @@ module Houston
 
     def devices
       unregistered_devices.collect{|device| device[:token]}
+    end
+
+    def certificate_data
+      return unless ENV['APN_CERTIFICATE']
+      if File.exist?(ENV['APN_CERTIFICATE'])
+        File.read(ENV['APN_CERTIFICATE'])
+      else
+        # Fallback and return the certificate itself; if it isn't readable, the
+        #   env var is likely the whole string version of the cert's `.pem`.
+        ENV['APN_CERTIFICATE']
+      end
     end
   end
 end

--- a/lib/houston/client.rb
+++ b/lib/houston/client.rb
@@ -82,13 +82,10 @@ module Houston
     end
 
     def certificate_data
-      return unless ENV['APN_CERTIFICATE']
-      if File.exist?(ENV['APN_CERTIFICATE'])
+      if ENV['APN_CERTIFICATE']
         File.read(ENV['APN_CERTIFICATE'])
-      else
-        # Fallback and return the certificate itself; if it isn't readable, the
-        #   env var is likely the whole string version of the cert's `.pem`.
-        ENV['APN_CERTIFICATE']
+      elsif ENV['APN_CERTIFICATE_DATA']
+        ENV['APN_CERTIFICATE_DATA']
       end
     end
   end


### PR DESCRIPTION
I really miss the ability to feed a certificate's `.pem` data into an ENV var, since this is (at least) how we've got it setup on a few of our Heroku instances, but this was taken away as of v2.2.3 (I think). This adds that functionality back, but also retains the new functionality of providing the file path (and makes that a first-attempt priority).