### PR TITLE
Remove exclamation point from message in command line example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Houston 2.0 supports the new [enhanced notification format](https://developer.ap
 
 Houston also comes with the `apn` binary, which provides a convenient way to test notifications from the command line.
 
-    $ apn push "<token>" -c /path/to/apple_push_notification.pem -m "Hello from the command line!"
+    $ apn push "<token>" -c /path/to/apple_push_notification.pem -m "Hello from the command line."
 
 ## Enabling Push Notifications on iOS
 


### PR DESCRIPTION
I guess you could also escape this character but didn't want to muddy up the message. Resolves the `"! event out found` error.
