### PR TITLE
apn-bin: Support for tokens in files, payloads in files and output invalid tokens to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.cer
 Gemfile.lock
 coverage/
+
+.DS_Store
+

--- a/bin/apn
+++ b/bin/apn
@@ -22,6 +22,7 @@ command :push do |c|
   c.description = ''
 
   c.example 'description', 'apn push <token> -m "Hello, World" -b 57 -s sosumi.aiff'
+  c.option '-t', '--tokenfile TOKEN_FILE', 'File with tokens to send the push to'
   c.option '-m', '--alert ALERT', 'Body of the alert to send in the push notification'
   c.option '-b', '--badge NUMBER', 'Badge number to set with the push notification'
   c.option '-s', '--sound SOUND', 'Sound to play with the notification'
@@ -32,9 +33,10 @@ command :push do |c|
   c.option '-e', '--environment ENV', [:production, :development], 'Environment to send push notification (production or development (default))'
   c.option '-c', '--certificate CERTIFICATE', 'Path to certificate (.pem) file'
   c.option '-p', '--[no]-passphrase', 'Prompt for a certificate passphrase'
+  c.option '-i', '--invalidfile INVALID_FILE', 'File to save invalid tokens to'
 
   c.action do |args, options|
-    say_error "One or more device tokens required" and abort if args.empty?
+    say_error "One or more device tokens required" and abort unless (options.tokenfile != nil and File.file?(options.tokenfile)) or not args.empty?
 
     @environment = options.environment.downcase.to_sym rescue :development
     say_error "Invalid environment,'#{@environment}' (should be either :development or :production)" and abort unless [:development, :production].include?(@environment)
@@ -53,7 +55,15 @@ command :push do |c|
 
     if options.payload
       begin
-        @data = JSON.parse(options.payload)
+        if options.payload[0] == '@'
+          filename = options.payload[1..options.payload.length]
+          say_error "Payload file doesn't exist" and abort unless File.file?(filename)
+
+          contents = File.open(filename, 'rb') { |file| file.read }
+          @data = JSON.parse(contents)
+        else
+          @data = JSON.parse(options.payload)
+        end
       rescue => message
         say_error "Exception parsing JSON payload: #{message}" and abort
       end
@@ -69,6 +79,18 @@ command :push do |c|
       placeholder = "Enter your alert message"
       @alert = ask_editor placeholder
       say_error "Payload contents required" and abort if @alert.nil? or @alert == placeholder
+    end
+
+    tokens = args
+
+    if options.tokenfile != nil
+      if File.file?(options.tokenfile)
+        File.open(options.tokenfile) do |f|
+          f.each_line do |line|
+            tokens << line
+          end
+        end
+      end
     end
 
     @notifications = []
@@ -110,6 +132,14 @@ command :push do |c|
           say_error "1 push notification unsuccessful (#{tokens})"
         else
           say_error "#{unsent.length} push notifications unsuccessful (#{tokens})"
+        end
+      end
+
+      say_error "#{client.devices.length} devices were invalid"
+
+      if options.invalidfile
+        File.open(options.invalidfile, "a+") do |f|
+          client.devices.each { |element| f.puts(element) }
         end
       end
 


### PR DESCRIPTION
Support for working with files instead of placing everything on the command line. Using a curl-like syntax.
