### PR TITLE
Adds the ability to send the `mutable-content` flag

### DIFF
--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -29,7 +29,7 @@ module Houston
 
     MAXIMUM_PAYLOAD_SIZE = 2048
 
-    attr_accessor :token, :alert, :badge, :sound, :category, :content_available, :custom_data, :id, :expiry, :priority
+    attr_accessor :token, :alert, :badge, :sound, :category, :content_available, :custom_data, :id, :expiry, :priority, :mutable_content
     attr_reader :sent_at
     attr_writer :apns_error_code
 
@@ -46,7 +46,7 @@ module Houston
       @id = options.delete(:id)
       @priority = options.delete(:priority)
       @content_available = options.delete(:content_available)
-
+      @mutable_content = options.delete(:mutable_content)
       @custom_data = options
     end
 
@@ -59,6 +59,7 @@ module Houston
       json['aps']['sound'] = @sound if @sound
       json['aps']['category'] = @category if @category
       json['aps']['content-available'] = 1 if @content_available
+      json['aps']['mutable-content'] = 1 if @mutable_content
 
       json
     end


### PR DESCRIPTION
To support iOS 10 Notification Extensions
