### PR TITLE
Add support of mutable-content: 1 (for iOS10 push notifications with attachments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Houston::Notification.new(:sound => '',
                           :content_available => true)
 ```
 
+### Mutable Notifications
+
+To send a mutable iOS10 push notification:
+
+```ruby
+Houston::Notification.new(:mutable_content => true)
+```
+
 ### Persistent Connections
 
 If you want to manage your own persistent connection to Apple push services, such as for background workers, here's how to do it:

--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -29,7 +29,7 @@ module Houston
 
     MAXIMUM_PAYLOAD_SIZE = 2048
 
-    attr_accessor :token, :alert, :badge, :sound, :category, :content_available, :custom_data, :id, :expiry, :priority
+    attr_accessor :token, :alert, :badge, :sound, :category, :content_available, :mutable_content, :custom_data, :id, :expiry, :priority
     attr_reader :sent_at
     attr_writer :apns_error_code
 
@@ -46,6 +46,7 @@ module Houston
       @id = options.delete(:id)
       @priority = options.delete(:priority)
       @content_available = options.delete(:content_available)
+      @mutable_content = options.delete(:mutable_content)
 
       @custom_data = options
     end
@@ -59,6 +60,7 @@ module Houston
       json['aps']['sound'] = @sound if @sound
       json['aps']['category'] = @category if @category
       json['aps']['content-available'] = 1 if @content_available
+      json['aps']['mutable-content'] = 1 if @mutable_content
 
       json
     end

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -135,6 +135,12 @@ describe Houston::Notification do
       })
     end
 
+    it 'should create a dictionary only with mutable-content' do
+      expect(Houston::Notification.new(mutable_content: true).payload).to eq({
+        'aps' => { 'mutable-content' => 1 }
+      })
+    end
+
     it 'should allow custom data inside aps key' do
       notification_options = { :badge => 567, 'aps' => { 'loc-key' => 'my-key' } }
       expect(Houston::Notification.new(notification_options).payload).to eq({


### PR DESCRIPTION
Convenience change for media attachments on iOS10.

Also possible to achieve the same result with:

```
notification.custom_data = { 'aps' => { 'mutable-content' => '1' }, 'image' => "https://url/to/image" }
```
