### PR TITLE
Fix Emoji when used with ActiveSupport::JSON

### DIFF
--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -88,7 +88,7 @@ module Houston
     end
 
     def valid?
-      payload.to_json.bytesize <= MAXIMUM_PAYLOAD_SIZE
+      JSON(payload).bytesize <= MAXIMUM_PAYLOAD_SIZE
     end
 
     def error

--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -102,7 +102,7 @@ module Houston
       end
 
       def payload_item
-        json = payload.to_json
+        json = JSON(payload)
         [2, json.bytes.count, json].pack('cna*')
       end
 


### PR DESCRIPTION
When i use `houston` with `ActiveSupport` the `ActiveSupport::JSON` `to_json`  will overwrite the `JSON`'s `to_json`method and Emojis doent display right

example with ActiveSupport::JSON:
```

[2] pry(main)> defined?(ActiveSupport::JSON) 
=> "constant"

[1] pry(main)> "💬".to_json
=> "\"\\uf4ac\""
```


example with JSON:

```

2.1.6 :003 > "💬".to_json
 => "\"💬\""
```