### PR TITLE
Only non-empty passphrase when creating key

### DIFF
--- a/lib/houston/connection.rb
+++ b/lib/houston/connection.rb
@@ -36,7 +36,11 @@ module Houston
       @socket = TCPSocket.new(@uri.host, @uri.port)
 
       context = OpenSSL::SSL::SSLContext.new
-      context.key = OpenSSL::PKey::RSA.new(@certificate, @passphrase)
+      if @passphrase.nil? || @passphrase.empty?
+        context.key = OpenSSL::PKey::RSA.new(@certificate)
+      else
+        context.key = OpenSSL::PKey::RSA.new(@certificate, @passphrase)
+      end
       context.cert = OpenSSL::X509::Certificate.new(@certificate)
 
       @ssl = OpenSSL::SSL::SSLSocket.new(@socket, context)


### PR DESCRIPTION
We should only pass non-empty passphrases when creating a key. If we
don't avoid empty passphrases, certificates without passphrases will
throw an error when attempting to create the key.