### PR TITLE
refactor(README): use unregistered_devices instead of devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ namespace :notifications do
   task device_token_feedback: [:environment] do
     APN.unregistered_devices.each do |device_hash|
       # Format: { token: token, timestamp: timestamp }
-      device = Device.find_by(token: device_hash['token'])
+      device = Device.find_by(token: device_hash[:token])
       next unless device.present?
       # Remove device token
       device.update_attribute(:device_token, nil)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ In `lib/tasks/notifications.rake`:
 ```ruby
 namespace :notifications do
   task device_token_feedback: [:environment] do
-    APN.devices.each do |device_hash|
+    APN.unregistered_devices.each do |device_hash|
       # Format: { token: token, timestamp: timestamp }
       device = Device.find_by(token: device_hash['token'])
       next unless device.present?


### PR DESCRIPTION
[unregistered_devices](https://github.com/nomad/houston/blob/master/lib/houston/client.rb#L65) returns hash, but [devices](https://github.com/nomad/houston/blob/master/lib/houston/client.rb#L80) returns array of tokens
Change token key from string key to [symbol](https://github.com/nomad/houston/blob/master/lib/houston/client.rb#L73)