### PR TITLE
set default passphrase to nil instead of the empty string.

### DIFF
--- a/bin/apn
+++ b/bin/apn
@@ -43,7 +43,7 @@ command :push do |c|
     say_error "Missing certificate file option (-c /path/to/certificate.pem)" and abort unless @certificate
     say_error "Could not find certificate file '#{@certificate}'" and abort unless File.exists?(@certificate)
 
-    @passphrase = options.passphrase ? password : ""
+    @passphrase = options.passphrase ? password : nil
 
     @alert = options.alert
     @badge = options.badge.nil? ? nil : options.badge.to_i
@@ -138,7 +138,7 @@ command :feedback do |c|
     say_error "Missing certificate file option (-c /path/to/certificate.pem)" and abort unless @certificate
     say_error "Could not find certificate file '#{@certificate}'" and abort unless File.exists?(@certificate)
 
-    @passphrase = options.passphrase ? password : ""
+    @passphrase = options.passphrase ? password : nil
 
     client = (@environment == :production) ? Houston::Client.production : Houston::Client.development
     client.certificate = File.read(@certificate)

--- a/lib/houston/connection.rb
+++ b/lib/houston/connection.rb
@@ -27,7 +27,7 @@ module Houston
     def initialize(uri, certificate, passphrase)
       @uri = URI(uri)
       @certificate = certificate.to_s
-      @passphrase = passphrase.to_s
+      @passphrase = passphrase.to_s unless passphrase.nil?              
     end
 
     def open


### PR DESCRIPTION
This fixes two bugs in the `apn` command line tool.

- `APN_CERTIFICATE_PASSPHRASE` was never being used because the passphrase would always have a value (the one provided by the user or the empty string).
- When using an unencrypted pem (not password protected) the command line would complain unless you provided *some* 4+ byte value password. This was because when no password was provided it would use the empty string and complain that the password was not long enough. See [comment] (https://github.com/nomad/houston/issues/146#issuecomment-359273095)

This pull request allows the password to be nil to fix the above issues. 
