### PR TITLE
Adds -r option to binary to pass the raw certificate

### DIFF
--- a/bin/apn
+++ b/bin/apn
@@ -31,6 +31,7 @@ command :push do |c|
   c.option '-P', '--payload PAYLOAD', 'JSON payload for notifications'
   c.option '-e', '--environment ENV', [:production, :development], 'Environment to send push notification (production or development (default))'
   c.option '-c', '--certificate CERTIFICATE', 'Path to certificate (.pem) file'
+  c.option '-r', '--rawcert CERTIFICATE VALUE', 'Value of the certificate (.pem) file'
   c.option '-p', '--[no]-passphrase', 'Prompt for a certificate passphrase'
 
   c.action do |args, options|
@@ -39,9 +40,14 @@ command :push do |c|
     @environment = options.environment.downcase.to_sym rescue :development
     say_error "Invalid environment,'#{@environment}' (should be either :development or :production)" and abort unless [:development, :production].include?(@environment)
 
-    @certificate = options.certificate
-    say_error "Missing certificate file option (-c /path/to/certificate.pem)" and abort unless @certificate
-    say_error "Could not find certificate file '#{@certificate}'" and abort unless File.exists?(@certificate)
+    if options.rawcert
+      @certificate = options.rawcert
+    else
+      @certificate = options.certificate
+      say_error "Missing certificate option (-c /path/to/certificate.pem or -r certificate_value)" and abort unless @certificate
+      say_error "Could not find certificate file '#{@certificate}'" and abort unless File.exists?(@certificate)
+      @certificate = File.read(@certificate)
+    end
 
     @passphrase = options.passphrase ? password : nil
 
@@ -85,7 +91,7 @@ command :push do |c|
     end
 
     client = (@environment == :production) ? Houston::Client.production : Houston::Client.development
-    client.certificate = File.read(@certificate)
+    client.certificate = @certificate
     client.passphrase = @passphrase
 
     begin
@@ -126,6 +132,7 @@ command :feedback do |c|
 
   c.example 'description', 'apn feedback -c /path/to/apple_push_certificate.pem'
   c.option '-c', '--certificate CERTIFICATE', 'Path to certificate (.pem) file'
+  c.option '-r', '--rawcert CERTIFICATE VALUE', 'Value of the certificate (.pem) file'
   c.option '-e', '--environment ENV', [:production, :development], 'Environment to send push notification (production or development (default))'
   c.option '-p', '--[no]-passphrase', 'Prompt for a certificate passphrase'
 
@@ -134,14 +141,19 @@ command :feedback do |c|
     @environment = options.environment.downcase.to_sym rescue :development
     say_error "Invalid environment,'#{@environment}' (should be either :development or :production)" and abort unless [:development, :production].include?(@environment)
 
-    @certificate = options.certificate
-    say_error "Missing certificate file option (-c /path/to/certificate.pem)" and abort unless @certificate
-    say_error "Could not find certificate file '#{@certificate}'" and abort unless File.exists?(@certificate)
+    if options.rawcert
+      @certificate = options.rawcert
+    else
+      @certificate = options.certificate
+      say_error "Missing certificate option (-c /path/to/certificate.pem or -r certificate_value)" and abort unless @certificate
+      say_error "Could not find certificate file '#{@certificate}'" and abort unless File.exists?(@certificate)
+      @certificate = File.read(@certificate)
+    end
 
     @passphrase = options.passphrase ? password : nil
 
     client = (@environment == :production) ? Houston::Client.production : Houston::Client.development
-    client.certificate = File.read(@certificate)
+    client.certificate = @certificate
     client.passphrase = @passphrase
 
     begin

--- a/bin/apn
+++ b/bin/apn
@@ -31,7 +31,7 @@ command :push do |c|
   c.option '-P', '--payload PAYLOAD', 'JSON payload for notifications'
   c.option '-e', '--environment ENV', [:production, :development], 'Environment to send push notification (production or development (default))'
   c.option '-c', '--certificate CERTIFICATE', 'Path to certificate (.pem) file'
-  c.option '-r', '--rawcert CERTIFICATE VALUE', 'Value of the certificate (.pem) file'
+  c.option '-r', '--raw-certificate CERTIFICATE VALUE', 'Actual content / value of the certificate (.pem) file'
   c.option '-p', '--[no]-passphrase', 'Prompt for a certificate passphrase'
 
   c.action do |args, options|
@@ -40,8 +40,8 @@ command :push do |c|
     @environment = options.environment.downcase.to_sym rescue :development
     say_error "Invalid environment,'#{@environment}' (should be either :development or :production)" and abort unless [:development, :production].include?(@environment)
 
-    if options.rawcert
-      @certificate = options.rawcert
+    if options.raw_certificate
+      @certificate = options.raw_certificate
     else
       @certificate = options.certificate
       say_error "Missing certificate option (-c /path/to/certificate.pem or -r certificate_value)" and abort unless @certificate
@@ -132,7 +132,7 @@ command :feedback do |c|
 
   c.example 'description', 'apn feedback -c /path/to/apple_push_certificate.pem'
   c.option '-c', '--certificate CERTIFICATE', 'Path to certificate (.pem) file'
-  c.option '-r', '--rawcert CERTIFICATE VALUE', 'Value of the certificate (.pem) file'
+  c.option '-r', '--raw-certificate CERTIFICATE VALUE', 'Actual content / value of the certificate (.pem) file'
   c.option '-e', '--environment ENV', [:production, :development], 'Environment to send push notification (production or development (default))'
   c.option '-p', '--[no]-passphrase', 'Prompt for a certificate passphrase'
 
@@ -141,8 +141,8 @@ command :feedback do |c|
     @environment = options.environment.downcase.to_sym rescue :development
     say_error "Invalid environment,'#{@environment}' (should be either :development or :production)" and abort unless [:development, :production].include?(@environment)
 
-    if options.rawcert
-      @certificate = options.rawcert
+    if options.raw_certificate
+      @certificate = options.raw_certificate
     else
       @certificate = options.certificate
       say_error "Missing certificate option (-c /path/to/certificate.pem or -r certificate_value)" and abort unless @certificate


### PR DESCRIPTION
## Adds -r option to binary to pass the raw certificate

### Original need

The original need is to have the ability not to store our certificates on the disk.
An additionnal need is to have custom loading process for the certificates in the app.

### Faced problem

The problem here is that the binary only takes a path to the certificate through the `-c` option.

### Proposed solution

The solution I want to propose here is to add a `-r` option to the binary so that we can pass the raw certificate.


### Let's discuss

I do not have the whole project context so maybe the way I did that is not the more efficient, I would be very pleased to have your feedbacks!